### PR TITLE
sort hadolint err

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,6 @@ RUN  dnf upgrade -y \
 RUN  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash \
      && . ~/.nvm/nvm.sh \
      && nvm install --lts \
-     && npm install -g @cyclonedx/cdxgen \
+     && npm install -g @cyclonedx/cdxgen@latest \
      && dnf clean all
 


### PR DESCRIPTION
hadolint DL3016:

   Pin versions in npm. 
   Instead of `npm install <package>` use `npm install <package>@<version>`