### PR TITLE
update image. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN  dnf upgrade -y \
 
 # Setting Up Node.js on an Amazon EC2 (Amazon Linux 2023)
 # https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-up-node-on-ec2-instance.html
-RUN  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash \
+RUN  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash \
      && . ~/.nvm/nvm.sh \
      && nvm install --lts \
      && npm install -g @cyclonedx/cdxgen@latest \


### PR DESCRIPTION
This is a nice-to-have change, but the main reason
is to trigger the concourse pipeline and have a new image
where the
```
 ... && npm install -g @cyclonedx/cdxgen@latest \
                                          ^^^^
```
will install the new`v1.6` which became 
an Ecma International Standard today
https://cyclonedx.org/news/cyclonedx-v1.6-now-an-ecma-international-standard/